### PR TITLE
Fixed construction skill issue

### DIFF
--- a/PostNukeRP/Gamemode/base/construction.lua
+++ b/PostNukeRP/Gamemode/base/construction.lua
@@ -17,22 +17,24 @@ function PNRP.SpawnBulkCrate( )
 			else allowed = false end
 			--If Right Class
 			if team.GetName(ply:Team()) == item.ClassSpawn or item.ClassSpawn == "All" or allowed == true then
-			
+				local ItemScrap = item.Scrap
+				local ItemSmall = item.SmallParts
+				local ItemChems = item.Chemicals
 				--Apply construction skill
 				if ply:GetSkill("Construction") > 0 then
 					for _, team in pairs(PNRP.Skills["Construction"].class) do
 						if ply:Team() == team then
-							item.Scrap = math.ceil(item.Scrap * (1 - (0.02 * ply:GetSkill("Construction"))))
-							item.SmallParts = math.ceil(item.SmallParts * (1 - (0.02 * ply:GetSkill("Construction"))))
-							item.Chemicals = math.ceil(item.Chemicals * (1 - (0.02 * ply:GetSkill("Construction"))))
+							ItemScrap = math.ceil(item.Scrap * (1 - (0.02 * ply:GetSkill("Construction"))))
+							ItemSmall = math.ceil(item.SmallParts * (1 - (0.02 * ply:GetSkill("Construction"))))
+							ItemChems = math.ceil(item.Chemicals * (1 - (0.02 * ply:GetSkill("Construction"))))
 						end
 					end
 				end
 				
 				--Verifies Player has the needed Materials to build the item
-				local totalScrap = item.Scrap * Count
-				local totalSmall = item.SmallParts * Count
-				local totalChems = item.Chemicals * Count
+				local totalScrap = ItemScrap * Count
+				local totalSmall = ItemSmall * Count
+				local totalChems = ItemChems * Count
 				if ply:GetResource("Scrap") >= totalScrap and ply:GetResource("Chemicals") >= totalChems and ply:GetResource("Small_Parts") >= totalSmall then 
 					enough = true
 				elseif ply:IsAdmin() and getServerSetting("adminNoCost") == 1 then 
@@ -223,19 +225,23 @@ function GM.BuildItem( ply, command, arg )
 			
 			if team.GetName(ply:Team()) == item.ClassSpawn or item.ClassSpawn == "All" or allowed == true then
 				--Apply construction skill
+				local ItemScrap = item.Scrap
+				local ItemSmall = item.SmallParts
+				local ItemChems = item.Chemicals
+				--Apply construction skill
 				if ply:GetSkill("Construction") > 0 then
 					for _, team in pairs(PNRP.Skills["Construction"].class) do
 						if ply:Team() == team then
-							item.Scrap = math.ceil(item.Scrap * (1 - (0.02 * ply:GetSkill("Construction"))))
-							item.SmallParts = math.ceil(item.SmallParts * (1 - (0.02 * ply:GetSkill("Construction"))))
-							item.Chemicals = math.ceil(item.Chemicals * (1 - (0.02 * ply:GetSkill("Construction"))))
+							ItemScrap = math.ceil(item.Scrap * (1 - (0.02 * ply:GetSkill("Construction"))))
+							ItemSmall = math.ceil(item.SmallParts * (1 - (0.02 * ply:GetSkill("Construction"))))
+							ItemChems = math.ceil(item.Chemicals * (1 - (0.02 * ply:GetSkill("Construction"))))
 						end
 					end
 				end
 				
 				local tr = ply:TraceFromEyes(200)
 				--Verifies Player has the needed Materials to build the item
-				if ply:GetResource("Scrap") >= item.Scrap and ply:GetResource("Chemicals") >= item.Chemicals and ply:GetResource("Small_Parts") >= item.SmallParts then 
+				if ply:GetResource("Scrap") >= ItemScrap and ply:GetResource("Chemicals") >= ItemChems and ply:GetResource("Small_Parts") >= ItemSmall then 
 					enough = true
 				elseif ply:IsAdmin() and getServerSetting("adminNoCost") == 1 then 
 					enough = true


### PR DESCRIPTION
The construction skill globally lowered the cost of the item whenever it was used to craft an item. Now the cost reduction is only applied to the specific crafting instance.